### PR TITLE
Adding ignore pattern for no-unused-vars

### DIFF
--- a/resources/linting/eslint/default.js
+++ b/resources/linting/eslint/default.js
@@ -10,7 +10,7 @@ module.exports = {
         indent: ['error', 4],
         quotes: ['error', 'single', { avoidEscape: true }],
         semi: ['error', 'always'],
-        'no-unused-vars': ['error', { argsIgnorePattern: '^__' }]
+        'no-unused-vars': ['error', { argsIgnorePattern: '^__', varsIgnorePattern: '^__' }]
     },
     parserOptions: {
         sourceType: 'module',


### PR DESCRIPTION
Adding same ignore pattern to vars as is used for args. This helps with destructuring, e.g. [__width, height] = getDimensions(x).